### PR TITLE
increase version

### DIFF
--- a/root/inc/plugins/unreadPosts.php
+++ b/root/inc/plugins/unreadPosts.php
@@ -49,7 +49,7 @@ function unreadPosts_info()
         'website' => 'https://tkacz.pro',
         'author' => 'Lukasz Tkacz',
         'authorsite' => 'https://tkacz.pro',
-        'version' => '1.13',
+        'version' => '1.14',
         'guid' => '',
         'compatibility' => '18*',
         'codename' => 'view_unread_posts',


### PR DESCRIPTION
There is a tag `1.14` in your GitHub repo 
https://github.com/lukasamd/MyBB-View_Unread_posts/releases/tag/1.14 
and the version `1.14` is registered in 
https://community.mybb.com/mods.php?action=download&pid=116 
This causes that MyBB admin console 
`/admin/index.php?module=config-plugins&action=check` 
tells me to download `1.14` because it thinks I have `1.13` 

Now, I noticed that this was already reported as #27 